### PR TITLE
Use exceptions to return null or undefined from C# to JS

### DIFF
--- a/Source/V8.Net/Exceptions.cs
+++ b/Source/V8.Net/Exceptions.cs
@@ -45,5 +45,13 @@ namespace V8.Net
         public V8ExecutionErrorException(InternalHandle handle, Exception innerException) : base(handle) { }
     }
 
+    public class V8ValueException : Exception
+    {
+        public static readonly V8ValueException Null = new V8ValueException();
+        public static readonly V8ValueException Undefined = new V8ValueException();
+
+        private V8ValueException() { }
+    }
+
     // ========================================================================================================================
 }

--- a/Source/V8.Net/ObjectTemplate.cs
+++ b/Source/V8.Net/ObjectTemplate.cs
@@ -130,6 +130,16 @@ namespace V8.Net
             }
             catch (Exception ex)
             {
+                if (ex.InnerException == V8ValueException.Null)
+                {
+                    return Engine.CreateNullValue();
+                }
+
+                if (ex.InnerException == V8ValueException.Undefined)
+                {
+                    return InternalHandle.Empty;
+                }
+
                 return _Engine.CreateError(Exceptions.GetFullErrorMessage(ex), JSValueType.ExecutionError);
             }
         }
@@ -148,6 +158,16 @@ namespace V8.Net
             }
             catch (Exception ex)
             {
+                if (ex.InnerException == V8ValueException.Null)
+                {
+                    return Engine.CreateNullValue();
+                }
+
+                if (ex.InnerException == V8ValueException.Undefined)
+                {
+                    return InternalHandle.Empty;
+                }
+
                 return _Engine.CreateError(Exceptions.GetFullErrorMessage(ex), JSValueType.ExecutionError);
             }
         }
@@ -219,6 +239,16 @@ namespace V8.Net
             }
             catch (Exception ex)
             {
+                if (ex.InnerException == V8ValueException.Null)
+                {
+                    return Engine.CreateNullValue();
+                }
+
+                if (ex.InnerException == V8ValueException.Undefined)
+                {
+                    return InternalHandle.Empty;
+                }
+
                 return _Engine.CreateError(Exceptions.GetFullErrorMessage(ex), JSValueType.ExecutionError);
             }
         }
@@ -237,6 +267,16 @@ namespace V8.Net
             }
             catch (Exception ex)
             {
+                if (ex.InnerException == V8ValueException.Null)
+                {
+                    return Engine.CreateNullValue();
+                }
+
+                if (ex.InnerException == V8ValueException.Undefined)
+                {
+                    return InternalHandle.Empty;
+                }
+
                 return _Engine.CreateError(Exceptions.GetFullErrorMessage(ex), JSValueType.ExecutionError);
             }
         }

--- a/Source/V8.Net/V8Engine_Binding.cs
+++ b/Source/V8.Net/V8Engine_Binding.cs
@@ -1424,6 +1424,16 @@ namespace V8.Net
                 }
                 catch (Exception ex)
                 {
+                    if (ex.InnerException == V8ValueException.Null)
+                    {
+                        return engine.CreateNullValue();
+                    }
+
+                    if (ex.InnerException == V8ValueException.Undefined)
+                    {
+                        return InternalHandle.Empty;
+                    }
+
                     var msg = "Failed to invoke method ";
                     if (expectedParameters != null)
                     {


### PR DESCRIPTION
**What is this change?**
This change adds the possibility to return null or undefined from C# methods to JS by throwing V8ValueException.Null or V8ValueException.Undefined.

**Why is this change needed?**
There is currently no way for people who only use the ScriptObject and ScriptMember attributes to return undefined from their C# methods.

**Example**

C#:
```
[ScriptObject("Person", ScriptMemberSecurity.NoAcccess)]
public class Person
{
	/// <summary>
	/// Returns 25 for i's between 0 and 50
	/// Returns 125 for i's between 100 and 150
	/// Returns undefined for everything else
	/// </summary>
	[ScriptMember("getValueFor", ScriptMemberSecurity.Permanent)]
	public int GetValueFor(int i)
	{
		if (i >= 0 && i <= 50)
		{
			return 25;
		}

		if (i >= 100 && i <= 150)
		{
			return 125;
		}

		throw V8ValueException.Undefined;
	}
}
```

JS:
```
var p = new Person();
var r0 = p.getValueFor(-5); // Returns undefined
var r1 = p.getValueFor(40); // Returns 25
var r2 = p.getValueFor(60); // Returns undefined
var r3 = p.getValueFor(120); // Returns 125
```

**//EDIT:**
Using throw V8ValueException.Null or V8ValueException.Undefined in properties is not implemented yet, but I would like to add this too.

**//EDIT2:**
Should now also work with named and indexed properties.